### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/duff.opam
+++ b/duff.opam
@@ -22,7 +22,7 @@ build: [
 
 depends: [
   "ocaml"    {>= "4.03.0"}
-  "dune"     {build}
+  "dune"
   "fmt"
   "cstruct"
   "cmdliner" {>= "1.0.2"}


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.